### PR TITLE
Update Indexer action to use latest published indexer core package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Building and contributing to this repo requires the following dependencies:
 
 1. [Node.js](https://nodejs.org/) v12 or later.
 1. [yarn](https://www.npmjs.com/package/yarn)
+1. [ncc](https://github.com/zeit/ncc) - CLI for compiling Node.js module into a single file
 
 We recommend using [VS Code](https://code.visualstudio.com/) for development.
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@actions/github": "^2.0.1",
 		"@actions/io": "^1.0.2",
 		"@actions/tool-cache": "^1.3.0",
-		"@cloudkernel/rich-code-nav-indexer-core": "^0.1.23-alpha",
+		"@cloudkernel/rich-code-nav-indexer-core": "^0.1.30-alpha",
 		"applicationinsights": "^1.6.0",
 		"axios": "^0.19.1",
 		"cloudbuild-task-github-actions": "^0.1.64-alpha"

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,14 +71,14 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@cloudkernel/rich-code-nav-indexer-core@^0.1.23-alpha":
-  version "0.1.23-alpha"
-  resolved "https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/npm/registry/@cloudkernel/rich-code-nav-indexer-core/-/rich-code-nav-indexer-core-0.1.23-alpha.tgz#4257bd2df8a49a5c4dfe1886bb28219dbdffc350"
-  integrity sha1-Qle9LfikmlxN/hiGuyghnb3/w1A=
+"@cloudkernel/rich-code-nav-indexer-core@^0.1.30-alpha":
+  version "0.1.30-alpha"
+  resolved "https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/npm/registry/@cloudkernel/rich-code-nav-indexer-core/-/rich-code-nav-indexer-core-0.1.30-alpha.tgz#4137f6fb86b84b80e1f2e154914d913e0655cfd1"
+  integrity sha1-QTf2+4a4S4Dh8uFUkU2RPgZVz9E=
   dependencies:
     applicationinsights "^1.2.0"
     axios "^0.18.1"
-    cloudbuild-task-contracts "^0.1.64-alpha"
+    cloudbuild-task-contracts "^0.1.66-alpha"
     minimatch "^3.0.4"
     mkdirp "^1.0.3"
     promisify-node "^0.5.0"
@@ -441,10 +441,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
-cloudbuild-task-contracts@0.1.64-alpha, cloudbuild-task-contracts@^0.1.64-alpha:
+cloudbuild-task-contracts@0.1.64-alpha:
   version "0.1.64-alpha"
   resolved "https://registry.npmjs.org/cloudbuild-task-contracts/-/cloudbuild-task-contracts-0.1.64-alpha.tgz#d79c0f1b1a3c67ce09f6a8176a4f7df6b1f3434b"
   integrity sha512-wE1kAKH1Slb9Q1QkGiwB2owmz2SCEhWlSJv2qTw2uWJk4HXi65+iHgfySOCdijsc4UPLMjl1UF1QL4LvkKdjwA==
+
+cloudbuild-task-contracts@^0.1.66-alpha:
+  version "0.1.66-alpha"
+  resolved "https://registry.yarnpkg.com/cloudbuild-task-contracts/-/cloudbuild-task-contracts-0.1.66-alpha.tgz#d0a3971f2c6b2113671487f35fc58f1091421ebf"
+  integrity sha512-EjLnavtqRsgacEzl81SvtYnvHsTf64BJEiryykrgUXrGeZLjuF78PGgn0MF7ugvINjN7J3nLFEmIS97mT/mMxw==
 
 cloudbuild-task-github-actions@^0.1.64-alpha:
   version "0.1.64-alpha"


### PR DESCRIPTION
Use the latest version of the Indexer core package. This will resolve error for not being able to install RichCodeNav.LSIF nuget package as dotnet tool on Prod and Int, e.g. https://github.com/xuachen/spring-petclinic/runs/644477716?check_suite_focus=true