### PR TITLE
Fix GitHub Action when run in other repos

### DIFF
--- a/lib/yarn-bootstrap.js
+++ b/lib/yarn-bootstrap.js
@@ -1,4 +1,4 @@
 const { spawn } = require('child_process');
 const { argv, exit } = require('process');
-const cp = spawn(`yarn node ${__dirname}/main.js`, argv.slice(2), { shell: true, stdio: "inherit" })
+const cp = spawn(`yarn node ./main.js`, argv.slice(2), { shell: true, stdio: "inherit", cwd: __dirname })
 cp.once('exit', code => exit(code))


### PR DESCRIPTION
The underlying problem was that the current working directory has to be within the github action's directory in order to pick up yarn v2.
This happens automatically in our own test job because the default cwd is the repo's directory which _is_ our github action's directory.
But in another user's repo, the cwd is the user's repo root. So when we spawn 'yarn node' we have to set cwd to our own github action directory.